### PR TITLE
improve search accuracy

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Kyowichi NISHI
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kyowichi NISHI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,28 @@ A utility library and CLI for full-text search built on Tantivy and Lindera.
 - `tokenizer-ngram` (default)
 - `tokenizer-lindera-ipadic` (optional)
 
+## Requirements
+
+- Rust 1.85+ (edition 2024)
+
+## Installation
+
+```bash
+cargo install traverze
+```
+
+With Lindera (IPADIC) tokenizer:
+
+```bash
+cargo install traverze --features tokenizer-lindera-ipadic
+```
+
 ## CLI
 
 ```bash
 traverze index [--index-dir <DIR>] [--with-snippet] [--reset] [FILES...]
 traverze remove [--index-dir <DIR>] <FILES...>
-traverze search [--index-dir <DIR>] [--limit <N>] [--with-snippet] [--snippet-max-chars <N>] [--snippet-format text|html] <QUERY>
+traverze search [--index-dir <DIR>] [--limit <N>] [--with-snippet] [--snippet-max-chars <N>] [--snippet-format text|html] [--query-preprocess none|analyze-and] <QUERY>
 ```
 
 Notes:
@@ -62,6 +78,70 @@ fn main() -> anyhow::Result<()> {
 }
 ```
 
+### Search with snippets
+
+```rust
+use traverze::{SearchOptions, SnippetFormat, SnippetOptions, Traverze};
+
+fn main() -> anyhow::Result<()> {
+    let engine = Traverze::new()?; // uses default ".traverze-index"
+
+    let options = SearchOptions {
+        limit: 10,
+        snippet: Some(SnippetOptions {
+            max_num_chars: 150,
+            format: SnippetFormat::Text,
+        }),
+        ..Default::default()
+    };
+
+    let hits = engine.search_with_options("tantivy", options)?;
+    for hit in hits {
+        println!("{} ({:.3})", hit.path, hit.score);
+        if let Some(snippet) = &hit.snippet {
+            println!("  {}", snippet);
+        }
+    }
+
+    Ok(())
+}
+```
+
+> **Note:** Snippet search requires the index to be built with `--with-snippet` (CLI) or
+> `Traverze::new_in_dir_for_indexing(dir, mode, true)` (library).
+> Use `engine.supports_snippet()` to check at runtime.
+
+### Remove files from the index
+
+```rust
+use std::path::PathBuf;
+use traverze::Traverze;
+
+fn main() -> anyhow::Result<()> {
+    let engine = Traverze::new()?;
+    let removed = engine.remove_files(&[PathBuf::from("old_file.txt")])?;
+    println!("removed {} file(s)", removed);
+    Ok(())
+}
+```
+
+### Select tokenizer mode explicitly
+
+```rust
+use std::path::Path;
+use traverze::{TokenizerMode, Traverze};
+
+fn main() -> anyhow::Result<()> {
+    // Use Lindera IPADIC tokenizer (requires `tokenizer-lindera-ipadic` feature)
+    let engine = Traverze::new_in_dir_with_mode(
+        Path::new(".traverze-index"),
+        TokenizerMode::LinderaIpadic,
+    )?;
+    // ...
+    Ok(())
+}
+```
+
 ## Third-Party Notices
 
 When distributing binaries or source artifacts (including crates.io packages),
@@ -69,3 +149,12 @@ review and include `THIRD_PARTY_NOTICES.md`.
 
 This is especially important when `tokenizer-lindera-ipadic` is enabled,
 because IPADIC dictionary data notice terms apply.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT License ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,6 @@ pub enum QueryPreprocess {
     None,
     #[default]
     AnalyzeAnd,
-    AnalyzeOriginalOrAnd,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -337,7 +336,7 @@ impl Traverze {
 fn preprocess_query(index: &Index, query: &str, mode: QueryPreprocess) -> Result<String> {
     match mode {
         QueryPreprocess::None => Ok(query.to_string()),
-        QueryPreprocess::AnalyzeAnd | QueryPreprocess::AnalyzeOriginalOrAnd => {
+        QueryPreprocess::AnalyzeAnd => {
             let mut analyzer = index
                 .tokenizers()
                 .get(TOKENIZER_NAME)
@@ -381,22 +380,12 @@ fn preprocess_query(index: &Index, query: &str, mode: QueryPreprocess) -> Result
                     })
                     .collect();
                 let and_query = expanded_parts.join(" AND ");
-                if mode == QueryPreprocess::AnalyzeOriginalOrAnd {
-                    let output = format!("({query}) OR ({and_query})");
-                    eprintln!(
-                        "query_preprocess\tmode={mode:?}\tinput={query}\ttokens={}\texpanded={}\toutput={output}",
-                        terms.join("|"),
-                        expanded_parts.join("|")
-                    );
-                    Ok(output)
-                } else {
-                    eprintln!(
-                        "query_preprocess\tmode={mode:?}\tinput={query}\ttokens={}\texpanded={}\toutput={and_query}",
-                        terms.join("|"),
-                        expanded_parts.join("|")
-                    );
-                    Ok(and_query)
-                }
+                eprintln!(
+                    "query_preprocess\tmode={mode:?}\tinput={query}\ttokens={}\texpanded={}\toutput={and_query}",
+                    terms.join("|"),
+                    expanded_parts.join("|")
+                );
+                Ok(and_query)
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,9 +309,9 @@ fn preprocess_query(index: &Index, query: &str, mode: QueryPreprocess) -> Result
                 }
             });
             if terms.is_empty() {
-                eprintln!(
-                    "query_preprocess\tmode={mode:?}\tinput={query}\ttokens=[]\toutput={query}"
-                );
+                // eprintln!(
+                //     "query_preprocess\tmode={mode:?}\tinput={query}\ttokens=[]\toutput={query}"
+                // );
                 Ok(query.to_string())
             } else {
                 // Build an AND query where each morphological token is expanded
@@ -340,11 +340,11 @@ fn preprocess_query(index: &Index, query: &str, mode: QueryPreprocess) -> Result
                     })
                     .collect();
                 let and_query = expanded_parts.join(" AND ");
-                eprintln!(
-                    "query_preprocess\tmode={mode:?}\tinput={query}\ttokens={}\texpanded={}\toutput={and_query}",
-                    terms.join("|"),
-                    expanded_parts.join("|")
-                );
+                // eprintln!(
+                //     "query_preprocess\tmode={mode:?}\tinput={query}\ttokens={}\texpanded={}\toutput={and_query}",
+                //     terms.join("|"),
+                //     expanded_parts.join("|")
+                // );
                 Ok(and_query)
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use tantivy::schema::{
     Field, IndexRecordOption, STORED, STRING, Schema, TextFieldIndexing, TextOptions, Value,
 };
 use tantivy::snippet::SnippetGenerator;
-use tantivy::tokenizer::{LowerCaser, NgramTokenizer, RemoveLongFilter, TextAnalyzer};
+use tantivy::tokenizer::{LowerCaser, NgramTokenizer, RemoveLongFilter, TextAnalyzer, TokenStream};
 use tantivy::{Index, ReloadPolicy, Term, doc};
 
 const TOKENIZER_NAME: &str = "traverze_ja";
@@ -54,6 +54,14 @@ pub enum SnippetFormat {
     Html,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum QueryPreprocess {
+    None,
+    #[default]
+    AnalyzeAnd,
+    AnalyzeOriginalOrAnd,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct SnippetOptions {
     pub max_num_chars: usize,
@@ -73,6 +81,7 @@ impl Default for SnippetOptions {
 pub struct SearchOptions {
     pub limit: usize,
     pub snippet: Option<SnippetOptions>,
+    pub query_preprocess: QueryPreprocess,
 }
 
 impl SearchOptions {
@@ -80,6 +89,7 @@ impl SearchOptions {
         Self {
             limit,
             snippet: None,
+            query_preprocess: QueryPreprocess::default(),
         }
     }
 }
@@ -160,6 +170,14 @@ impl Traverze {
     }
 
     pub fn index_files(&self, files: &[PathBuf]) -> Result<usize> {
+        self.index_files_with_debug(files, None)
+    }
+
+    pub fn index_files_with_debug(
+        &self,
+        files: &[PathBuf],
+        debug_token_limit: Option<usize>,
+    ) -> Result<usize> {
         let mut writer = self
             .index
             .writer::<tantivy::schema::TantivyDocument>(50_000_000)
@@ -174,6 +192,17 @@ impl Traverze {
             let content = fs::read_to_string(&abs)
                 .or_else(|_| fs::read(&abs).map(|b| String::from_utf8_lossy(&b).into_owned()))
                 .with_context(|| format!("failed to read file: {}", abs.display()))?;
+
+            if let Some(limit) = debug_token_limit {
+                let (tokens, token_count) = self.debug_tokenize_preview(&content, limit)?;
+                eprintln!(
+                    "index_tokenize\tpath={}\ttoken_count={}\tpreview_limit={}\ttokens={}",
+                    abs.display(),
+                    token_count,
+                    limit,
+                    tokens.join("|")
+                );
+            }
 
             let path_text = abs.to_string_lossy().to_string();
             writer.delete_term(Term::from_field_text(self.path_field, &path_text));
@@ -226,8 +255,9 @@ impl Traverze {
         let searcher = reader.searcher();
 
         let query_parser = QueryParser::for_index(&self.index, vec![self.contents_field]);
+        let processed_query = preprocess_query(&self.index, query, options.query_preprocess)?;
         let parsed_query = query_parser
-            .parse_query(query)
+            .parse_query(&processed_query)
             .context("failed to parse query")?;
 
         let top_docs = searcher
@@ -281,6 +311,108 @@ impl Traverze {
     pub fn supports_snippet(&self) -> bool {
         self.contents_is_stored
     }
+
+    fn debug_tokenize_preview(&self, text: &str, limit: usize) -> Result<(Vec<String>, usize)> {
+        let mut analyzer = self
+            .index
+            .tokenizers()
+            .get(TOKENIZER_NAME)
+            .ok_or_else(|| anyhow!("`{TOKENIZER_NAME}` tokenizer is not registered"))?;
+        let mut stream = analyzer.token_stream(text);
+        let mut tokens = Vec::new();
+        let mut token_count = 0usize;
+        stream.process(&mut |token| {
+            token_count += 1;
+            if token.text.is_empty() {
+                return;
+            }
+            if tokens.len() < limit {
+                tokens.push(token.text.to_string());
+            }
+        });
+        Ok((tokens, token_count))
+    }
+}
+
+fn preprocess_query(index: &Index, query: &str, mode: QueryPreprocess) -> Result<String> {
+    match mode {
+        QueryPreprocess::None => Ok(query.to_string()),
+        QueryPreprocess::AnalyzeAnd | QueryPreprocess::AnalyzeOriginalOrAnd => {
+            let mut analyzer = index
+                .tokenizers()
+                .get(TOKENIZER_NAME)
+                .ok_or_else(|| anyhow!("`{TOKENIZER_NAME}` tokenizer is not registered"))?;
+            let mut stream = analyzer.token_stream(query);
+            let mut terms = Vec::new();
+            stream.process(&mut |token| {
+                if !token.text.is_empty() {
+                    terms.push(token.text.to_string());
+                }
+            });
+            if terms.is_empty() {
+                eprintln!(
+                    "query_preprocess\tmode={mode:?}\tinput={query}\ttokens=[]\toutput={query}"
+                );
+                Ok(query.to_string())
+            } else {
+                // Build an AND query where each morphological token is expanded
+                // with a character-level phrase fallback.  This handles the case
+                // where the index tokenizer splits a word differently from the
+                // query tokenizer due to context-dependent morphological analysis.
+                //
+                // For a CJK token with >1 char (e.g. "日付") we emit:
+                //   (日付 OR "日 付")
+                // The phrase query "日 付" matches when the index has the
+                // individual characters as adjacent tokens.
+                let expanded_parts: Vec<String> = terms
+                    .iter()
+                    .map(|term| {
+                        let chars: Vec<char> = term.chars().collect();
+                        if chars.len() > 1 && chars.iter().all(|c| is_cjk_like(*c)) {
+                            let char_phrase = chars
+                                .iter()
+                                .map(|c| c.to_string())
+                                .collect::<Vec<_>>()
+                                .join(" ");
+                            format!("({term} OR \"{char_phrase}\")")
+                        } else {
+                            term.clone()
+                        }
+                    })
+                    .collect();
+                let and_query = expanded_parts.join(" AND ");
+                if mode == QueryPreprocess::AnalyzeOriginalOrAnd {
+                    let output = format!("({query}) OR ({and_query})");
+                    eprintln!(
+                        "query_preprocess\tmode={mode:?}\tinput={query}\ttokens={}\texpanded={}\toutput={output}",
+                        terms.join("|"),
+                        expanded_parts.join("|")
+                    );
+                    Ok(output)
+                } else {
+                    eprintln!(
+                        "query_preprocess\tmode={mode:?}\tinput={query}\ttokens={}\texpanded={}\toutput={and_query}",
+                        terms.join("|"),
+                        expanded_parts.join("|")
+                    );
+                    Ok(and_query)
+                }
+            }
+        }
+    }
+}
+
+/// Returns `true` for CJK ideographs, Hiragana, and Katakana characters
+/// that are likely to appear as individual tokens in a morphological index.
+fn is_cjk_like(c: char) -> bool {
+    matches!(c,
+        '\u{3040}'..='\u{309F}'   // Hiragana
+        | '\u{30A0}'..='\u{30FF}' // Katakana
+        | '\u{4E00}'..='\u{9FFF}' // CJK Unified Ideographs
+        | '\u{3400}'..='\u{4DBF}' // CJK Extension A
+        | '\u{F900}'..='\u{FAFF}' // CJK Compatibility Ideographs
+        | '\u{FF65}'..='\u{FF9F}' // Halfwidth Katakana
+    )
 }
 
 fn normalize_path(path: &Path) -> PathBuf {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,9 +236,13 @@ impl Traverze {
 
         let query_parser = QueryParser::for_index(&self.index, vec![self.contents_field]);
         let processed_query = preprocess_query(&self.index, query, options.query_preprocess)?;
-        let parsed_query = query_parser
-            .parse_query(&processed_query)
-            .context("failed to parse query")?;
+        let (parsed_query, parse_errors) = query_parser.parse_query_lenient(&processed_query);
+        if !parse_errors.is_empty() {
+            eprintln!(
+                "warning: query parse errors (ignored): {:?}",
+                parse_errors
+            );
+        }
 
         let top_docs = searcher
             .search(&parsed_query, &TopDocs::with_limit(options.limit))
@@ -334,6 +338,8 @@ fn preprocess_query(index: &Index, query: &str, mode: QueryPreprocess) -> Result
                                 .collect::<Vec<_>>()
                                 .join(" ");
                             format!("({term} OR \"{char_phrase}\")")
+                        } else if is_tantivy_keyword(term) {
+                            format!("\"{}\"" , term)
                         } else {
                             term.clone()
                         }
@@ -349,6 +355,15 @@ fn preprocess_query(index: &Index, query: &str, mode: QueryPreprocess) -> Result
             }
         }
     }
+}
+
+/// Returns `true` if the given string is a Tantivy query syntax reserved keyword.
+/// These must be quoted when used as literal search terms.
+fn is_tantivy_keyword(s: &str) -> bool {
+    matches!(
+        s.to_uppercase().as_str(),
+        "AND" | "OR" | "NOT" | "IN" | "TO"
+    )
 }
 
 /// Returns `true` for CJK ideographs, Hiragana, and Katakana characters

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::fs;
+﻿use std::fs;
 use std::path::{Path, PathBuf};
 
 #[cfg(not(feature = "tokenizer-lindera-ipadic"))]
@@ -169,14 +169,6 @@ impl Traverze {
     }
 
     pub fn index_files(&self, files: &[PathBuf]) -> Result<usize> {
-        self.index_files_with_debug(files, None)
-    }
-
-    pub fn index_files_with_debug(
-        &self,
-        files: &[PathBuf],
-        debug_token_limit: Option<usize>,
-    ) -> Result<usize> {
         let mut writer = self
             .index
             .writer::<tantivy::schema::TantivyDocument>(50_000_000)
@@ -191,17 +183,6 @@ impl Traverze {
             let content = fs::read_to_string(&abs)
                 .or_else(|_| fs::read(&abs).map(|b| String::from_utf8_lossy(&b).into_owned()))
                 .with_context(|| format!("failed to read file: {}", abs.display()))?;
-
-            if let Some(limit) = debug_token_limit {
-                let (tokens, token_count) = self.debug_tokenize_preview(&content, limit)?;
-                eprintln!(
-                    "index_tokenize\tpath={}\ttoken_count={}\tpreview_limit={}\ttokens={}",
-                    abs.display(),
-                    token_count,
-                    limit,
-                    tokens.join("|")
-                );
-            }
 
             let path_text = abs.to_string_lossy().to_string();
             writer.delete_term(Term::from_field_text(self.path_field, &path_text));
@@ -309,27 +290,6 @@ impl Traverze {
 
     pub fn supports_snippet(&self) -> bool {
         self.contents_is_stored
-    }
-
-    fn debug_tokenize_preview(&self, text: &str, limit: usize) -> Result<(Vec<String>, usize)> {
-        let mut analyzer = self
-            .index
-            .tokenizers()
-            .get(TOKENIZER_NAME)
-            .ok_or_else(|| anyhow!("`{TOKENIZER_NAME}` tokenizer is not registered"))?;
-        let mut stream = analyzer.token_stream(text);
-        let mut tokens = Vec::new();
-        let mut token_count = 0usize;
-        stream.process(&mut |token| {
-            token_count += 1;
-            if token.text.is_empty() {
-                return;
-            }
-            if tokens.len() < limit {
-                tokens.push(token.text.to_string());
-            }
-        });
-        Ok((tokens, token_count))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,6 @@ impl From<SnippetFormatArg> for traverze::SnippetFormat {
 enum QueryPreprocessArg {
     None,
     AnalyzeAnd,
-    AnalyzeOriginalOrAnd,
 }
 
 impl From<QueryPreprocessArg> for traverze::QueryPreprocess {
@@ -97,7 +96,6 @@ impl From<QueryPreprocessArg> for traverze::QueryPreprocess {
         match value {
             QueryPreprocessArg::None => Self::None,
             QueryPreprocessArg::AnalyzeAnd => Self::AnalyzeAnd,
-            QueryPreprocessArg::AnalyzeOriginalOrAnd => Self::AnalyzeOriginalOrAnd,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,12 +27,6 @@ enum Commands {
         /// Delete and recreate the index
         #[arg(long, default_value_t = false)]
         reset: bool,
-        /// Print tokenization preview while indexing (index-side)
-        #[arg(long, default_value_t = false)]
-        debug_index_tokens: bool,
-        /// Max number of tokens to print per file when --debug-index-tokens is enabled
-        #[arg(long, default_value_t = 80)]
-        debug_index_token_limit: usize,
         /// Files to index
         files: Vec<PathBuf>,
     },
@@ -108,8 +102,6 @@ fn main() -> Result<()> {
             index_dir,
             with_snippet,
             reset,
-            debug_index_tokens,
-            debug_index_token_limit,
             files,
         } => {
             if reset && files.is_empty() {
@@ -138,8 +130,7 @@ fn main() -> Result<()> {
                 }
                 Err(err) => return Err(err),
             };
-            let debug_limit = debug_index_tokens.then_some(debug_index_token_limit);
-            let (indexed, elapsed) = time_block(|| engine.index_files_with_debug(&files, debug_limit))?;
+            let (indexed, elapsed) = time_block(|| engine.index_files(&files))?;
             println!("indexed {} file(s)", indexed);
             eprintln!("index_time_ms\t{:.3}", elapsed_ms(elapsed));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,12 @@ enum Commands {
         /// Delete and recreate the index
         #[arg(long, default_value_t = false)]
         reset: bool,
+        /// Print tokenization preview while indexing (index-side)
+        #[arg(long, default_value_t = false)]
+        debug_index_tokens: bool,
+        /// Max number of tokens to print per file when --debug-index-tokens is enabled
+        #[arg(long, default_value_t = 80)]
+        debug_index_token_limit: usize,
         /// Files to index
         files: Vec<PathBuf>,
     },
@@ -56,6 +62,9 @@ enum Commands {
         /// Output format for snippets
         #[arg(long, value_enum, default_value_t = SnippetFormatArg::Text)]
         snippet_format: SnippetFormatArg,
+        /// Query preprocessing mode
+        #[arg(long, value_enum, default_value_t = QueryPreprocessArg::AnalyzeAnd)]
+        query_preprocess: QueryPreprocessArg,
         /// Search query string
         query: String,
     },
@@ -76,6 +85,23 @@ impl From<SnippetFormatArg> for traverze::SnippetFormat {
     }
 }
 
+#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+enum QueryPreprocessArg {
+    None,
+    AnalyzeAnd,
+    AnalyzeOriginalOrAnd,
+}
+
+impl From<QueryPreprocessArg> for traverze::QueryPreprocess {
+    fn from(value: QueryPreprocessArg) -> Self {
+        match value {
+            QueryPreprocessArg::None => Self::None,
+            QueryPreprocessArg::AnalyzeAnd => Self::AnalyzeAnd,
+            QueryPreprocessArg::AnalyzeOriginalOrAnd => Self::AnalyzeOriginalOrAnd,
+        }
+    }
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -84,6 +110,8 @@ fn main() -> Result<()> {
             index_dir,
             with_snippet,
             reset,
+            debug_index_tokens,
+            debug_index_token_limit,
             files,
         } => {
             if reset && files.is_empty() {
@@ -112,7 +140,8 @@ fn main() -> Result<()> {
                 }
                 Err(err) => return Err(err),
             };
-            let (indexed, elapsed) = time_block(|| engine.index_files(&files))?;
+            let debug_limit = debug_index_tokens.then_some(debug_index_token_limit);
+            let (indexed, elapsed) = time_block(|| engine.index_files_with_debug(&files, debug_limit))?;
             println!("indexed {} file(s)", indexed);
             eprintln!("index_time_ms\t{:.3}", elapsed_ms(elapsed));
         }
@@ -128,6 +157,7 @@ fn main() -> Result<()> {
             with_snippet,
             snippet_max_chars,
             snippet_format,
+            query_preprocess,
             query,
         } => {
             let engine = traverze::Traverze::new_in_dir(&index_dir)?;
@@ -144,6 +174,7 @@ fn main() -> Result<()> {
                     max_num_chars: snippet_max_chars,
                     format: snippet_format.into(),
                 }),
+                query_preprocess: query_preprocess.into(),
             };
             let (hits, elapsed) =
                 time_block(|| engine.search_with_options(&query, search_options))?;


### PR DESCRIPTION
## Summary

- Add query preprocessing pipeline to improve Japanese/CJK search accuracy
- Introduce `QueryPreprocess` enum (`None` / `AnalyzeAnd`) to control preprocessing behavior
- Switch query parsing from strict `parse_query()` to lenient `parse_query_lenient()` to handle parse errors gracefully
- Add Apache and MIT licenses, update README with licensing information

## What Changed

### Query Preprocessing (`src/lib.rs`)

Added a `preprocess_query()` function that runs before Tantivy's query parser:

1. **Morphological tokenization + AND join** — Splits the query into tokens using the registered tokenizer and joins them with `AND` (e.g. `日付管理` → `日付 AND 管理`), ensuring all terms must appear in results.
2. **CJK token expansion** — For multi-character CJK tokens, emits both the morpheme and a character-level phrase fallback (e.g. `日付` → `(日付 OR "日 付")`). This handles cases where the index tokenizer splits a word differently from the query tokenizer due to context-dependent morphological analysis.
3. **Reserved keyword quoting** — Automatically wraps Tantivy query syntax keywords (`AND`, `OR`, `NOT`, `IN`, `TO`) in quotes when they appear as literal search terms.
4. **Lenient parsing** — Parse errors are now emitted as warnings to stderr instead of failing the search.

### CLI (`src/main.rs`)

- Added `--query-preprocess` flag (default: `analyze-and`) to allow users to opt out of preprocessing with `--query-preprocess none`.

## Motivation

Japanese morphological analyzers are context-sensitive: the same character sequence may be tokenized differently at index time vs. query time, causing missed matches. The `AnalyzeAnd` mode bridges this gap by expanding query tokens to cover both the morphological form and the raw character sequence, significantly improving recall for Japanese/CJK queries.