### PR TITLE
list all indexed files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,6 +2673,7 @@ dependencies = [
  "lindera",
  "lindera-tantivy",
  "tantivy",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ clap = { version = "4.5", features = ["derive"] }
 tantivy = "0.25.0"
 lindera = { version = "2.2.0", optional = true }
 lindera-tantivy = { version = "2.0.0", optional = true, default-features = false }
+
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ cargo install traverze --features tokenizer-lindera-ipadic
 
 ```bash
 traverze index [--index-dir <DIR>] [--with-snippet] [--reset] [FILES...]
+traverze list [--index-dir <DIR>]
 traverze remove [--index-dir <DIR>] <FILES...>
 traverze search [--index-dir <DIR>] [--limit <N>] [--with-snippet] [--snippet-max-chars <N>] [--snippet-format text|html] [--query-preprocess none|analyze-and] <QUERY>
 ```
@@ -36,6 +37,7 @@ Notes:
 - `index --reset` without files only deletes the index directory.
 - To enable snippets, build index with `index --with-snippet`.
 - If `search --with-snippet` is used on a non-snippet index, recreate with `index --reset --with-snippet`.
+- `list` outputs one indexed file path per line.
 
 ## Library Usage
 
@@ -110,6 +112,22 @@ fn main() -> anyhow::Result<()> {
 > **Note:** Snippet search requires the index to be built with `--with-snippet` (CLI) or
 > `Traverze::new_in_dir_for_indexing(dir, mode, true)` (library).
 > Use `engine.supports_snippet()` to check at runtime.
+
+### List indexed files
+
+```rust
+use traverze::Traverze;
+
+fn main() -> anyhow::Result<()> {
+    let engine = Traverze::new()?;
+    let paths = engine.list_files()?;
+    for path in &paths {
+        println!("{}", path);
+    }
+    println!("{} file(s)", paths.len());
+    Ok(())
+}
+```
 
 ### Remove files from the index
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,4 +489,74 @@ mod tests {
             crate::TokenizerMode::LinderaIpadic
         );
     }
+
+    #[test]
+    fn list_files_empty_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine =
+            crate::Traverze::new_in_dir_with_mode(dir.path(), crate::TokenizerMode::Ngram)
+                .unwrap();
+        let files = engine.list_files().unwrap();
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn list_files_returns_indexed_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let index_dir = dir.path().join("index");
+        let file_a = dir.path().join("a.txt");
+        let file_b = dir.path().join("b.txt");
+        std::fs::write(&file_a, "hello world").unwrap();
+        std::fs::write(&file_b, "foo bar").unwrap();
+
+        let engine = crate::Traverze::new_in_dir_for_indexing(
+            &index_dir,
+            crate::TokenizerMode::Ngram,
+            false,
+        )
+        .unwrap();
+        let count = engine.index_files(&[file_a.clone(), file_b.clone()]).unwrap();
+        assert_eq!(count, 2);
+
+        let files = engine.list_files().unwrap();
+        assert_eq!(files.len(), 2);
+        // list_files returns sorted paths
+        let canonical_a = std::fs::canonicalize(&file_a).unwrap().to_string_lossy().to_string();
+        let canonical_b = std::fs::canonicalize(&file_b).unwrap().to_string_lossy().to_string();
+        assert!(files.contains(&canonical_a));
+        assert!(files.contains(&canonical_b));
+    }
+
+    #[test]
+    fn list_files_excludes_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let index_dir = dir.path().join("index");
+        let file_a = dir.path().join("a.txt");
+        let file_b = dir.path().join("b.txt");
+        std::fs::write(&file_a, "hello").unwrap();
+        std::fs::write(&file_b, "world").unwrap();
+
+        {
+            let engine = crate::Traverze::new_in_dir_for_indexing(
+                &index_dir,
+                crate::TokenizerMode::Ngram,
+                false,
+            )
+            .unwrap();
+            engine.index_files(&[file_a.clone(), file_b.clone()]).unwrap();
+        }
+        {
+            let engine = crate::Traverze::new_in_dir_with_mode(
+                &index_dir,
+                crate::TokenizerMode::Ngram,
+            )
+            .unwrap();
+            engine.remove_files(&[file_a]).unwrap();
+
+            let files = engine.list_files().unwrap();
+            assert_eq!(files.len(), 1);
+            let canonical_b = std::fs::canonicalize(&file_b).unwrap().to_string_lossy().to_string();
+            assert_eq!(files[0], canonical_b);
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,41 @@ impl Traverze {
         Ok(hits)
     }
 
+    pub fn list_files(&self) -> Result<Vec<String>> {
+        let reader = self
+            .index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::OnCommitWithDelay)
+            .try_into()
+            .context("failed to build index reader")?;
+        let searcher = reader.searcher();
+
+        let mut paths = Vec::new();
+        for segment_reader in searcher.segment_readers() {
+            let store_reader = segment_reader
+                .get_store_reader(0)
+                .context("failed to open store reader")?;
+            for doc_id in 0..segment_reader.max_doc() {
+                if segment_reader.is_deleted(doc_id) {
+                    continue;
+                }
+                let doc: tantivy::schema::TantivyDocument =
+                    store_reader.get(doc_id).context("failed to load document")?;
+                if let Some(path) = doc
+                    .get_first(self.path_field)
+                    .and_then(|v| v.as_str())
+                {
+                    if !path.is_empty() {
+                        paths.push(path.to_string());
+                    }
+                }
+            }
+        }
+
+        paths.sort();
+        Ok(paths)
+    }
+
     pub fn supports_snippet(&self) -> bool {
         self.contents_is_stored
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,12 @@ enum Commands {
         #[arg(required = true)]
         files: Vec<PathBuf>,
     },
+    /// List all indexed files
+    List {
+        /// Path to the index directory
+        #[arg(long, default_value = ".traverze-index")]
+        index_dir: PathBuf,
+    },
     /// Search the index for a query
     Search {
         /// Path to the index directory
@@ -133,6 +139,14 @@ fn main() -> Result<()> {
             let (indexed, elapsed) = time_block(|| engine.index_files(&files))?;
             println!("indexed {} file(s)", indexed);
             eprintln!("index_time_ms\t{:.3}", elapsed_ms(elapsed));
+        }
+        Commands::List { index_dir } => {
+            let engine = traverze::Traverze::new_in_dir(&index_dir)?;
+            let (paths, elapsed) = time_block(|| engine.list_files())?;
+            for path in &paths {
+                println!("{}", path);
+            }
+            eprintln!("list_time_ms\t{:.3}\t{} file(s)", elapsed_ms(elapsed), paths.len());
         }
         Commands::Remove { index_dir, files } => {
             let engine = traverze::Traverze::new_in_dir(&index_dir)?;


### PR DESCRIPTION
## Summary

- Add `list_files()` method to `Traverze` struct to retrieve all indexed file paths
- Add `traverze list [--index-dir <DIR>]` CLI subcommand
- Add unit tests for `list_files` (empty index, indexed paths, removed files exclusion)
- Update README with CLI usage and library example

## Details

### Library API

```rust
impl Traverze {
    pub fn list_files(&self) -> Result<Vec<String>>
}
```

- Iterates all segments, skips deleted documents, collects `path` field values
- Returns sorted `Vec<String>`

### CLI

```
traverze list [--index-dir <DIR>]
```

- Outputs one file path per line to stdout
- Outputs elapsed time and file count to stderr

### Performance

Benchmarked with 1,000 files (release build, `--with-snippet` index):

| Condition | list time |
|-----------|-----------|
| with-snippet | ~20ms |
| without-snippet | ~20ms |

No measurable performance difference between `--with-snippet` and without. With a single commit (few segments), listing 1,000 files takes ~20ms.

### Tests

- `list_files_empty_index` — returns empty list for empty index
- `list_files_returns_indexed_paths` — returns correct paths after indexing
- `list_files_excludes_removed` — excludes removed files from results

---

## 概要

- `Traverze` 構造体にインデックス済みファイルパスを全件取得する `list_files()` メソッドを追加
- `traverze list [--index-dir <DIR>]` CLI サブコマンドを追加
- `list_files` のユニットテストを追加（空インデックス、インデクシング後のパス、削除済みファイルの除外）
- README に CLI の使い方とライブラリの使用例を追記

## 詳細

### ライブラリ API

```rust
impl Traverze {
    pub fn list_files(&self) -> Result<Vec<String>>
}
```

- 全セグメントを走査し、削除済みドキュメントをスキップ、`path` フィールドの値を収集
- ソート済みの `Vec<String>` を返す

### CLI

```
traverze list [--index-dir <DIR>]
```

- stdout に1行1パスで出力
- stderr に実行時間とファイル数を出力

### パフォーマンス

1,000ファイルでのベンチマーク（リリースビルド、`--with-snippet` インデックス）:

| 条件 | list 所要時間 |
|------|-------------|
| with-snippet | ~20ms |
| without-snippet | ~20ms |

`--with-snippet` の有無による性能差はなし。セグメント数が少ない場合（1回のコミットでインデクシング）、1,000ファイルで約20ms。

### テスト

- `list_files_empty_index` — 空インデックスで空リストを返す
- `list_files_returns_indexed_paths` — インデクシング後に正しいパスが返る
- `list_files_excludes_removed` — 削除済みファイルがリストから除外される
