### PR TITLE
rename traverze public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A utility library and CLI for full-text search built on Tantivy and Lindera.
 
 ## Features
 
-- `tokenizer-ngram` (default)
-- `tokenizer-lindera-ipadic` (optional)
+- `tokenizer-ngram` (default) — Character-based 2–3 gram tokenizer. Works with all languages including CJK. Lightweight with no additional dictionary data.
+- `tokenizer-lindera-ipadic` (optional) — Japanese morphological analyzer using the IPADIC dictionary. Produces more accurate tokens for Japanese text but increases binary size (~50 MB).
 
 ## Requirements
 
@@ -38,6 +38,21 @@ Notes:
 - To enable snippets, build index with `index --with-snippet`.
 - If `search --with-snippet` is used on a non-snippet index, recreate with `index --reset --with-snippet`.
 - `list` outputs one indexed file path per line.
+- `--query-preprocess` controls how the query is tokenized before searching:
+  - `none` — pass the query string directly to Tantivy's query parser.
+  - `analyze-and` (default) — tokenize the query with the index's analyzer, combine tokens with AND. CJK substrings are wrapped as phrase queries to preserve word boundaries. Tantivy reserved keywords (`AND`, `OR`, `NOT`, etc.) are automatically quoted.
+
+### Search output format
+
+Results are printed as tab-separated values to stdout (one hit per line):
+
+```
+<score>\t<path>                   # without --with-snippet
+<score>\t<path>\t<snippet>        # with --with-snippet
+```
+
+Newlines, tabs, and carriage returns in snippets are escaped as `\n`, `\t`, `\r`.
+Timing information is printed to stderr.
 
 ## Library Usage
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ fn main() -> anyhow::Result<()> {
 
 > **Note:** Snippet search requires the index to be built with `--with-snippet` (CLI) or
 > `Traverze::builder().with_snippet(true).open()` (library).
-> Use `engine.supports_snippet()` to check at runtime.
+> Use `engine.has_snippet()` to check at runtime.
 
 ### List indexed files
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ fn main() -> anyhow::Result<()> {
         PathBuf::from("README.md"),
         PathBuf::from("src/lib.rs"),
     ];
-    engine.index_files(&files)?;
+    engine.index(&files)?;
 
     let hits = engine.search("tantivy", 10)?;
     for hit in hits {
@@ -120,7 +120,7 @@ use traverze::Traverze;
 
 fn main() -> anyhow::Result<()> {
     let engine = Traverze::new()?;
-    let paths = engine.list_files()?;
+    let paths = engine.list()?;
     for path in &paths {
         println!("{}", path);
     }
@@ -137,7 +137,7 @@ use traverze::Traverze;
 
 fn main() -> anyhow::Result<()> {
     let engine = Traverze::new()?;
-    let removed = engine.remove_files(&[PathBuf::from("old_file.txt")])?;
+    let removed = engine.remove(&[PathBuf::from("old_file.txt")])?;
     println!("removed {} file(s)", removed);
     Ok(())
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ traverze = { version = "0.2", features = ["tokenizer-lindera-ipadic"] }
 
 ```rust
 use std::path::PathBuf;
-use traverze::Traverze;
+use traverze::{SearchOptions, Traverze};
 
 fn main() -> anyhow::Result<()> {
     let index_dir = PathBuf::from("./.traverze-index");
@@ -71,7 +71,7 @@ fn main() -> anyhow::Result<()> {
     ];
     engine.index(&files)?;
 
-    let hits = engine.search("tantivy", 10)?;
+    let hits = engine.search("tantivy", SearchOptions::with_limit(10))?;
     for hit in hits {
         println!("{} ({:.3})", hit.path, hit.score);
     }
@@ -97,7 +97,7 @@ fn main() -> anyhow::Result<()> {
         ..Default::default()
     };
 
-    let hits = engine.search_with_options("tantivy", options)?;
+    let hits = engine.search("tantivy", options)?;
     for hit in hits {
         println!("{} ({:.3})", hit.path, hit.score);
         if let Some(snippet) = &hit.snippet {

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ use std::path::PathBuf;
 use traverze::{SearchOptions, Traverze};
 
 fn main() -> anyhow::Result<()> {
-    let index_dir = PathBuf::from("./.traverze-index");
-    let engine = Traverze::new_in_dir(&index_dir)?;
+    let engine = Traverze::new()?;
 
     let files = vec![
         PathBuf::from("README.md"),
@@ -110,7 +109,7 @@ fn main() -> anyhow::Result<()> {
 ```
 
 > **Note:** Snippet search requires the index to be built with `--with-snippet` (CLI) or
-> `Traverze::new_in_dir_for_indexing(dir, mode, true)` (library).
+> `Traverze::builder().with_snippet(true).open()` (library).
 > Use `engine.supports_snippet()` to check at runtime.
 
 ### List indexed files
@@ -146,15 +145,13 @@ fn main() -> anyhow::Result<()> {
 ### Select tokenizer mode explicitly
 
 ```rust
-use std::path::Path;
 use traverze::{TokenizerMode, Traverze};
 
 fn main() -> anyhow::Result<()> {
     // Use Lindera IPADIC tokenizer (requires `tokenizer-lindera-ipadic` feature)
-    let engine = Traverze::new_in_dir_with_mode(
-        Path::new(".traverze-index"),
-        TokenizerMode::LinderaIpadic,
-    )?;
+    let engine = Traverze::builder()
+        .mode(TokenizerMode::LinderaIpadic)
+        .open()?;
     // ...
     Ok(())
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cargo install traverze --features tokenizer-lindera-ipadic
 traverze index [--index-dir <DIR>] [--with-snippet] [--reset] [FILES...]
 traverze list [--index-dir <DIR>]
 traverze remove [--index-dir <DIR>] <FILES...>
-traverze search [--index-dir <DIR>] [--limit <N>] [--with-snippet] [--snippet-max-chars <N>] [--snippet-format text|html] [--query-preprocess none|analyze-and] <QUERY>
+traverze search [--index-dir <DIR>] [--limit <N>] [--with-snippet] [--snippet-max-chars <N>] [--snippet-format text|html] [--query-preprocess plain|auto] <QUERY>
 ```
 
 Notes:
@@ -39,8 +39,8 @@ Notes:
 - If `search --with-snippet` is used on a non-snippet index, recreate with `index --reset --with-snippet`.
 - `list` outputs one indexed file path per line.
 - `--query-preprocess` controls how the query is tokenized before searching:
-  - `none` — pass the query string directly to Tantivy's query parser.
-  - `analyze-and` (default) — tokenize the query with the index's analyzer, combine tokens with AND. CJK substrings are wrapped as phrase queries to preserve word boundaries. Tantivy reserved keywords (`AND`, `OR`, `NOT`, etc.) are automatically quoted.
+  - `plain` — pass the query string directly to Tantivy's query parser.
+  - `auto` (default) — tokenize the query with the index's analyzer, combine tokens with AND. CJK substrings are wrapped as phrase queries to preserve word boundaries. Tantivy reserved keywords (`AND`, `OR`, `NOT`, etc.) are automatically quoted.
 
 ### Search output format
 

--- a/src/bin/compare_bench.rs
+++ b/src/bin/compare_bench.rs
@@ -95,7 +95,7 @@ fn run_mode(base_dir: &Path, files: &[PathBuf], mode: TokenizerMode, label: &str
     let engine = Traverze::new_in_dir_with_mode(&index_dir, mode)?;
 
     let start = Instant::now();
-    let indexed = engine.index_files(files)?;
+    let indexed = engine.index(files)?;
     let index_elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
     if indexed != files.len() {
         bail!(

--- a/src/bin/compare_bench.rs
+++ b/src/bin/compare_bench.rs
@@ -109,7 +109,7 @@ fn run_mode(base_dir: &Path, files: &[PathBuf], mode: TokenizerMode, label: &str
     let mut total_hits = 0usize;
     for _ in 0..SEARCH_REPEAT {
         for query in QUERIES {
-            total_hits += engine.search(query, 20)?.len();
+            total_hits += engine.search(query, traverze::SearchOptions::with_limit(20))?.len();
         }
     }
     let search_elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;

--- a/src/bin/compare_bench.rs
+++ b/src/bin/compare_bench.rs
@@ -92,7 +92,10 @@ fn run_mode(base_dir: &Path, files: &[PathBuf], mode: TokenizerMode, label: &str
             .with_context(|| format!("failed to cleanup {}", index_dir.display()))?;
     }
 
-    let engine = Traverze::new_in_dir_with_mode(&index_dir, mode)?;
+    let engine = Traverze::builder()
+        .index_dir(&index_dir)
+        .mode(mode)
+        .open()?;
 
     let start = Instant::now();
     let indexed = engine.index(files)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,15 +217,7 @@ impl Traverze {
         Ok(count)
     }
 
-    pub fn search(&self, query: &str, limit: usize) -> Result<Vec<SearchHit>> {
-        self.search_with_options(query, SearchOptions::with_limit(limit))
-    }
-
-    pub fn search_with_options(
-        &self,
-        query: &str,
-        options: SearchOptions,
-    ) -> Result<Vec<SearchHit>> {
+    pub fn search(&self, query: &str, options: SearchOptions) -> Result<Vec<SearchHit>> {
         let reader = self
             .index
             .reader_builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use tantivy::tokenizer::{LowerCaser, NgramTokenizer, RemoveLongFilter, TextAnaly
 use tantivy::{Index, ReloadPolicy, Term, doc};
 
 const TOKENIZER_NAME: &str = "traverze_ja";
-const DEFAULT_INDEX_DIR: &str = ".traverze-index";
+pub const DEFAULT_INDEX_DIR: &str = ".traverze-index";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenizerMode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,9 @@ pub enum SnippetFormat {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum QueryPreprocess {
-    None,
+    Plain,
     #[default]
-    AnalyzeAnd,
+    Auto,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -343,8 +343,8 @@ impl Traverze {
 
 fn preprocess_query(index: &Index, query: &str, mode: QueryPreprocess) -> Result<String> {
     match mode {
-        QueryPreprocess::None => Ok(query.to_string()),
-        QueryPreprocess::AnalyzeAnd => {
+        QueryPreprocess::Plain => Ok(query.to_string()),
+        QueryPreprocess::Auto => {
             let mut analyzer = index
                 .tokenizers()
                 .get(TOKENIZER_NAME)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ impl TraverzeBuilder {
             self.mode,
             build_schema(self.with_snippet),
         )?;
-        if self.with_snippet && !engine.supports_snippet() {
+        if self.with_snippet && !engine.has_snippet() {
             return Err(anyhow!(
                 "index snippet support mismatch: expected enabled, but existing index is disabled"
             ));
@@ -336,7 +336,7 @@ impl Traverze {
         Ok(paths)
     }
 
-    pub fn supports_snippet(&self) -> bool {
+    pub fn has_snippet(&self) -> bool {
         self.contents_is_stored
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ impl Traverze {
         })
     }
 
-    pub fn index_files(&self, files: &[PathBuf]) -> Result<usize> {
+    pub fn index(&self, files: &[PathBuf]) -> Result<usize> {
         let mut writer = self
             .index
             .writer::<tantivy::schema::TantivyDocument>(50_000_000)
@@ -199,7 +199,7 @@ impl Traverze {
         Ok(count)
     }
 
-    pub fn remove_files(&self, files: &[PathBuf]) -> Result<usize> {
+    pub fn remove(&self, files: &[PathBuf]) -> Result<usize> {
         let mut writer = self
             .index
             .writer::<tantivy::schema::TantivyDocument>(50_000_000)
@@ -292,7 +292,7 @@ impl Traverze {
         Ok(hits)
     }
 
-    pub fn list_files(&self) -> Result<Vec<String>> {
+    pub fn list(&self) -> Result<Vec<String>> {
         let reader = self
             .index
             .reader_builder()
@@ -496,7 +496,7 @@ mod tests {
         let engine =
             crate::Traverze::new_in_dir_with_mode(dir.path(), crate::TokenizerMode::Ngram)
                 .unwrap();
-        let files = engine.list_files().unwrap();
+        let files = engine.list().unwrap();
         assert!(files.is_empty());
     }
 
@@ -515,12 +515,12 @@ mod tests {
             false,
         )
         .unwrap();
-        let count = engine.index_files(&[file_a.clone(), file_b.clone()]).unwrap();
+        let count = engine.index(&[file_a.clone(), file_b.clone()]).unwrap();
         assert_eq!(count, 2);
 
-        let files = engine.list_files().unwrap();
+        let files = engine.list().unwrap();
         assert_eq!(files.len(), 2);
-        // list_files returns sorted paths
+        // list returns sorted paths
         let canonical_a = std::fs::canonicalize(&file_a).unwrap().to_string_lossy().to_string();
         let canonical_b = std::fs::canonicalize(&file_b).unwrap().to_string_lossy().to_string();
         assert!(files.contains(&canonical_a));
@@ -543,7 +543,7 @@ mod tests {
                 false,
             )
             .unwrap();
-            engine.index_files(&[file_a.clone(), file_b.clone()]).unwrap();
+            engine.index(&[file_a.clone(), file_b.clone()]).unwrap();
         }
         {
             let engine = crate::Traverze::new_in_dir_with_mode(
@@ -551,9 +551,9 @@ mod tests {
                 crate::TokenizerMode::Ngram,
             )
             .unwrap();
-            engine.remove_files(&[file_a]).unwrap();
+            engine.remove(&[file_a]).unwrap();
 
-            let files = engine.list_files().unwrap();
+            let files = engine.list().unwrap();
             assert_eq!(files.len(), 1);
             let canonical_b = std::fs::canonicalize(&file_b).unwrap().to_string_lossy().to_string();
             assert_eq!(files[0], canonical_b);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,37 +107,54 @@ pub struct Traverze {
     contents_is_stored: bool,
 }
 
-impl Traverze {
-    pub fn new() -> Result<Self> {
-        Self::new_in_dir(Path::new(DEFAULT_INDEX_DIR))
+pub struct TraverzeBuilder {
+    index_dir: PathBuf,
+    mode: TokenizerMode,
+    with_snippet: bool,
+}
+
+impl TraverzeBuilder {
+    pub fn index_dir(mut self, dir: &Path) -> Self {
+        self.index_dir = dir.to_path_buf();
+        self
     }
 
-    pub fn new_in_dir(index_dir: &Path) -> Result<Self> {
-        Self::new_in_dir_with_mode(index_dir, default_tokenizer_mode())
+    pub fn mode(mut self, mode: TokenizerMode) -> Self {
+        self.mode = mode;
+        self
     }
 
-    pub fn new_in_dir_with_mode(index_dir: &Path, mode: TokenizerMode) -> Result<Self> {
-        Self::open_or_create(index_dir, mode, build_schema(false))
+    pub fn with_snippet(mut self, enabled: bool) -> Self {
+        self.with_snippet = enabled;
+        self
     }
 
-    pub fn new_in_dir_for_indexing(
-        index_dir: &Path,
-        mode: TokenizerMode,
-        with_snippet: bool,
-    ) -> Result<Self> {
-        let engine = Self::open_or_create(index_dir, mode, build_schema(with_snippet))?;
-        if engine.supports_snippet() != with_snippet {
-            let expected = if with_snippet { "enabled" } else { "disabled" };
-            let actual = if engine.supports_snippet() {
-                "enabled"
-            } else {
-                "disabled"
-            };
+    pub fn open(self) -> Result<Traverze> {
+        let engine = Traverze::open_or_create(
+            &self.index_dir,
+            self.mode,
+            build_schema(self.with_snippet),
+        )?;
+        if self.with_snippet && !engine.supports_snippet() {
             return Err(anyhow!(
-                "index snippet support mismatch: expected {expected}, but existing index is {actual}"
+                "index snippet support mismatch: expected enabled, but existing index is disabled"
             ));
         }
         Ok(engine)
+    }
+}
+
+impl Traverze {
+    pub fn new() -> Result<Self> {
+        Self::builder().open()
+    }
+
+    pub fn builder() -> TraverzeBuilder {
+        TraverzeBuilder {
+            index_dir: PathBuf::from(DEFAULT_INDEX_DIR),
+            mode: default_tokenizer_mode(),
+            with_snippet: false,
+        }
     }
 
     fn open_or_create(index_dir: &Path, mode: TokenizerMode, schema: Schema) -> Result<Self> {
@@ -485,9 +502,11 @@ mod tests {
     #[test]
     fn list_files_empty_index() {
         let dir = tempfile::tempdir().unwrap();
-        let engine =
-            crate::Traverze::new_in_dir_with_mode(dir.path(), crate::TokenizerMode::Ngram)
-                .unwrap();
+        let engine = crate::Traverze::builder()
+            .index_dir(dir.path())
+            .mode(crate::TokenizerMode::Ngram)
+            .open()
+            .unwrap();
         let files = engine.list().unwrap();
         assert!(files.is_empty());
     }
@@ -501,12 +520,11 @@ mod tests {
         std::fs::write(&file_a, "hello world").unwrap();
         std::fs::write(&file_b, "foo bar").unwrap();
 
-        let engine = crate::Traverze::new_in_dir_for_indexing(
-            &index_dir,
-            crate::TokenizerMode::Ngram,
-            false,
-        )
-        .unwrap();
+        let engine = crate::Traverze::builder()
+            .index_dir(&index_dir)
+            .mode(crate::TokenizerMode::Ngram)
+            .open()
+            .unwrap();
         let count = engine.index(&[file_a.clone(), file_b.clone()]).unwrap();
         assert_eq!(count, 2);
 
@@ -529,20 +547,19 @@ mod tests {
         std::fs::write(&file_b, "world").unwrap();
 
         {
-            let engine = crate::Traverze::new_in_dir_for_indexing(
-                &index_dir,
-                crate::TokenizerMode::Ngram,
-                false,
-            )
-            .unwrap();
+            let engine = crate::Traverze::builder()
+                .index_dir(&index_dir)
+                .mode(crate::TokenizerMode::Ngram)
+                .open()
+                .unwrap();
             engine.index(&[file_a.clone(), file_b.clone()]).unwrap();
         }
         {
-            let engine = crate::Traverze::new_in_dir_with_mode(
-                &index_dir,
-                crate::TokenizerMode::Ngram,
-            )
-            .unwrap();
+            let engine = crate::Traverze::builder()
+                .index_dir(&index_dir)
+                .mode(crate::TokenizerMode::Ngram)
+                .open()
+                .unwrap();
             engine.remove(&[file_a]).unwrap();
 
             let files = engine.list().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,11 +120,10 @@ fn main() -> Result<()> {
             if reset && index_dir.exists() {
                 fs::remove_dir_all(&index_dir)?;
             }
-            let engine_result = traverze::Traverze::new_in_dir_for_indexing(
-                &index_dir,
-                traverze::default_tokenizer_mode(),
-                with_snippet,
-            );
+            let engine_result = traverze::Traverze::builder()
+                .index_dir(&index_dir)
+                .with_snippet(with_snippet)
+                .open();
             let engine = match engine_result {
                 Ok(engine) => engine,
                 Err(err) if err.to_string().contains("index snippet support mismatch") => {
@@ -141,7 +140,7 @@ fn main() -> Result<()> {
             eprintln!("index_time_ms\t{:.3}", elapsed_ms(elapsed));
         }
         Commands::List { index_dir } => {
-            let engine = traverze::Traverze::new_in_dir(&index_dir)?;
+            let engine = traverze::Traverze::builder().index_dir(&index_dir).open()?;
             let (paths, elapsed) = time_block(|| engine.list())?;
             for path in &paths {
                 println!("{}", path);
@@ -149,7 +148,7 @@ fn main() -> Result<()> {
             eprintln!("list_time_ms\t{:.3}\t{} file(s)", elapsed_ms(elapsed), paths.len());
         }
         Commands::Remove { index_dir, files } => {
-            let engine = traverze::Traverze::new_in_dir(&index_dir)?;
+            let engine = traverze::Traverze::builder().index_dir(&index_dir).open()?;
             let (removed, elapsed) = time_block(|| engine.remove(&files))?;
             println!("removed {} file(s)", removed);
             eprintln!("remove_time_ms\t{:.3}", elapsed_ms(elapsed));
@@ -163,7 +162,7 @@ fn main() -> Result<()> {
             query_preprocess,
             query,
         } => {
-            let engine = traverze::Traverze::new_in_dir(&index_dir)?;
+            let engine = traverze::Traverze::builder().index_dir(&index_dir).open()?;
             if with_snippet && !engine.supports_snippet() {
                 return Err(anyhow!(
                     "this index does not support snippet. run `traverze index --index-dir {} --reset` and then `traverze index --index-dir {} --with-snippet <FILES...>`",

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ enum Commands {
     /// Index files for full-text search
     Index {
         /// Path to the index directory
-        #[arg(long, default_value = ".traverze-index")]
+        #[arg(long, default_value = traverze::DEFAULT_INDEX_DIR)]
         index_dir: PathBuf,
         /// Store file contents for snippet generation
         #[arg(long, default_value_t = false)]
@@ -33,7 +33,7 @@ enum Commands {
     /// Remove files from the index
     Remove {
         /// Path to the index directory
-        #[arg(long, default_value = ".traverze-index")]
+        #[arg(long, default_value = traverze::DEFAULT_INDEX_DIR)]
         index_dir: PathBuf,
         /// Files to remove from the index
         #[arg(required = true)]
@@ -42,13 +42,13 @@ enum Commands {
     /// List all indexed files
     List {
         /// Path to the index directory
-        #[arg(long, default_value = ".traverze-index")]
+        #[arg(long, default_value = traverze::DEFAULT_INDEX_DIR)]
         index_dir: PathBuf,
     },
     /// Search the index for a query
     Search {
         /// Path to the index directory
-        #[arg(long, default_value = ".traverze-index")]
+        #[arg(long, default_value = traverze::DEFAULT_INDEX_DIR)]
         index_dir: PathBuf,
         /// Maximum number of results to return
         #[arg(long, default_value_t = 20)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,13 +136,13 @@ fn main() -> Result<()> {
                 }
                 Err(err) => return Err(err),
             };
-            let (indexed, elapsed) = time_block(|| engine.index_files(&files))?;
+            let (indexed, elapsed) = time_block(|| engine.index(&files))?;
             println!("indexed {} file(s)", indexed);
             eprintln!("index_time_ms\t{:.3}", elapsed_ms(elapsed));
         }
         Commands::List { index_dir } => {
             let engine = traverze::Traverze::new_in_dir(&index_dir)?;
-            let (paths, elapsed) = time_block(|| engine.list_files())?;
+            let (paths, elapsed) = time_block(|| engine.list())?;
             for path in &paths {
                 println!("{}", path);
             }
@@ -150,7 +150,7 @@ fn main() -> Result<()> {
         }
         Commands::Remove { index_dir, files } => {
             let engine = traverze::Traverze::new_in_dir(&index_dir)?;
-            let (removed, elapsed) = time_block(|| engine.remove_files(&files))?;
+            let (removed, elapsed) = time_block(|| engine.remove(&files))?;
             println!("removed {} file(s)", removed);
             eprintln!("remove_time_ms\t{:.3}", elapsed_ms(elapsed));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ fn main() -> Result<()> {
                 query_preprocess: query_preprocess.into(),
             };
             let (hits, elapsed) =
-                time_block(|| engine.search_with_options(&query, search_options))?;
+                time_block(|| engine.search(&query, search_options))?;
             for hit in hits {
                 if let Some(snippet) = hit.snippet {
                     let escaped = snippet

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ fn main() -> Result<()> {
             query,
         } => {
             let engine = traverze::Traverze::builder().index_dir(&index_dir).open()?;
-            if with_snippet && !engine.supports_snippet() {
+            if with_snippet && !engine.has_snippet() {
                 return Err(anyhow!(
                     "this index does not support snippet. run `traverze index --index-dir {} --reset` and then `traverze index --index-dir {} --with-snippet <FILES...>`",
                     index_dir.display(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ enum Commands {
         #[arg(long, value_enum, default_value_t = SnippetFormatArg::Text)]
         snippet_format: SnippetFormatArg,
         /// Query preprocessing mode
-        #[arg(long, value_enum, default_value_t = QueryPreprocessArg::AnalyzeAnd)]
+        #[arg(long, value_enum, default_value_t = QueryPreprocessArg::Auto)]
         query_preprocess: QueryPreprocessArg,
         /// Search query string
         query: String,
@@ -87,15 +87,15 @@ impl From<SnippetFormatArg> for traverze::SnippetFormat {
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]
 enum QueryPreprocessArg {
-    None,
-    AnalyzeAnd,
+    Plain,
+    Auto,
 }
 
 impl From<QueryPreprocessArg> for traverze::QueryPreprocess {
     fn from(value: QueryPreprocessArg) -> Self {
         match value {
-            QueryPreprocessArg::None => Self::None,
-            QueryPreprocessArg::AnalyzeAnd => Self::AnalyzeAnd,
+            QueryPreprocessArg::Plain => Self::Plain,
+            QueryPreprocessArg::Auto => Self::Auto,
         }
     }
 }


### PR DESCRIPTION
## Summary

Simplify and unify the public API with breaking changes, and improve documentation.

### API Renames

- `index_files()` → `index()`
- `remove_files()` → `remove()`
- `list_files()` → `list()`
- `supports_snippet()` → `has_snippet()`

### Constructor Consolidation (Builder Pattern)

Replaced 4 constructors (`new`, `new_in_dir`, `new_with_mode`, `new_in_dir_for_indexing`) with a builder pattern.

```rust
// Before
let engine = Traverze::new_in_dir_for_indexing(&dir, true)?;

// After
let engine = Traverze::builder()
    .index_dir(&dir)
    .with_snippet(true)
    .open()?;
```

`Traverze::new()` is kept as a shortcut for default settings.

### Search Method Consolidation

Merged `search()` and `search_with_options()` into a single `search(query, options)`.

```rust
// Before
let hits = engine.search("query")?;
let hits = engine.search_with_options("query", options)?;

// After
let hits = engine.search("query", SearchOptions::with_limit(20))?;
```

### QueryPreprocess Rename

- `QueryPreprocess::None` → `QueryPreprocess::Plain`
- `QueryPreprocess::AnalyzeAnd` → `QueryPreprocess::Auto`

CLI option also changed: `--query-preprocess none|analyze-and` → `--query-preprocess plain|auto`.

### Public Constant

Exposed `DEFAULT_INDEX_DIR` as `pub const`, eliminating 4 duplicated string literals in `main.rs`.

### Documentation (README.md)

- Added Ngram vs Lindera IPADIC feature descriptions
- Documented `--query-preprocess` option (`plain` / `auto`)
- Documented tab-separated search output format
- Updated all library usage examples to the new API

---

## 概要

公開APIの簡素化・統一と、ドキュメントの充実を行いました。破壊的変更を含みます。

### API リネーム

- `index_files()` → `index()`
- `remove_files()` → `remove()`
- `list_files()` → `list()`
- `supports_snippet()` → `has_snippet()`

### コンストラクタの整理（ビルダーパターン導入）

4つのコンストラクタ（`new`, `new_in_dir`, `new_with_mode`, `new_in_dir_for_indexing`）を廃止し、ビルダーパターンに統合しました。

```rust
// Before
let engine = Traverze::new_in_dir_for_indexing(&dir, true)?;

// After
let engine = Traverze::builder()
    .index_dir(&dir)
    .with_snippet(true)
    .open()?;
```

`Traverze::new()` はデフォルト設定のショートカットとして維持。

### search メソッドの統合

`search()` と `search_with_options()` を `search(query, options)` に統合しました。

```rust
// Before
let hits = engine.search("query")?;
let hits = engine.search_with_options("query", options)?;

// After
let hits = engine.search("query", SearchOptions::with_limit(20))?;
```

### QueryPreprocess のリネーム

- `QueryPreprocess::None` → `QueryPreprocess::Plain`
- `QueryPreprocess::AnalyzeAnd` → `QueryPreprocess::Auto`

CLIオプションも `--query-preprocess none|analyze-and` → `--query-preprocess plain|auto` に変更。

### 定数の公開

`DEFAULT_INDEX_DIR` を `pub const` として公開し、`main.rs` の4箇所の重複リテラルを解消。

### ドキュメント（README.md）

- Features セクションに Ngram / Lindera IPADIC の違いを記載
- `--query-preprocess` オプション（`plain` / `auto`）の説明を追加
- CLI検索出力のタブ区切りフォーマットを記載
- ライブラリ使用例をすべて新APIに更新
